### PR TITLE
feat: add `parentsByModelId` and `columnWithTbl` methods to Query Bui…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [5.4.0](https://github.com/efureev/laravel-trees/compare/v5.3.0...v5.4.0) (2025-08-26)
+
+### Added
+
+- Method `parentsByModelId` for Query Builder. It allows you to get all parents of a model by its id (Without a main
+  model). If you know `id` - you can select a list of parents. (Only 1 Query instead of 2)
+- Method `columnWithTbl` for Query Builder. It allows you to get a column with a table name
+
 ## [5.3.0](https://github.com/efureev/laravel-trees/compare/v5.2.1...v5.3.0) (2025-03-08)
 
 ### Added

--- a/docs/ReceivingNodes.md
+++ b/docs/ReceivingNodes.md
@@ -34,7 +34,7 @@ $parent = $node->parent;
 $parent = $node->parent()->first();
 ```
 
-### To get a Parents chains
+### To get Parents chains
 
 > @return Collection
 
@@ -125,4 +125,59 @@ $nextNode = $node->nextSibling()->first();
 ```php
 $prevNode = $node->prev()->first();
 $nextNode = $node->next()->first();
+```
+
+## Receiving through Queries without Models
+
+### root
+
+Returns a query for root nodes.
+
+```php
+MultiCategory::root();
+```
+
+### notRoot
+
+Returns a query for non-root nodes.
+
+```php
+MultiCategory::notRoot();
+```
+
+### parentsByModelId
+
+Returns a collection of parents of the node with the specified id.
+
+NB: In progress. Works only for multi-tree nodes.
+
+```php
+MultiCategory::parentsByModelId($node31->id)->get();
+MultiCategory::parentsByModelId($node31->id, level: 1)->get();
+MultiCategory::parentsByModelId($node31->id, andSelf: true)->get();
+```
+
+### byTree
+
+Returns a query for nodes of the specified tree.
+
+```php
+MultiCategory::byTree($id);
+MultiCategory::byTree($id)->get();
+```
+
+### toLevel
+
+Returns a query for nodes of the specified level.
+
+```php
+Category::toLevel(1);
+```
+
+### byParent
+
+Returns a query for nodes of the specified parent.
+
+```php
+Category::byParent($pid);
 ```

--- a/tests/Functional/Tree/Multi/QueryBuilder/ParentsByModelIdTest.php
+++ b/tests/Functional/Tree/Multi/QueryBuilder/ParentsByModelIdTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fureev\Trees\Tests\Functional\Tree\Multi\QueryBuilder;
+
+use Fureev\Trees\Tests\Functional\AbstractFunctionalTreeTestCase;
+use Fureev\Trees\Tests\models\v5\MultiCategory;
+use PHPUnit\Framework\Attributes\Test;
+
+class ParentsByModelIdTest extends AbstractFunctionalTreeTestCase
+{
+    /**
+     * @return class-string<MultiCategory>
+     */
+    protected static function modelClass(): string
+    {
+        return MultiCategory::class;
+    }
+
+    #[Test]
+    public function basic(): void
+    {
+        /** @var MultiCategory $modelRoot */
+        $modelRoot = static::model(['title' => 'root node']);
+        $modelRoot->save();
+
+        $treeId = $modelRoot->tree_id;
+        static::assertNotNull($treeId);
+
+        // Level 2
+        /** @var MultiCategory $node21 */
+        $node21 = static::model(['title' => 'child 2.1']);
+        $node21->appendTo($modelRoot)->save();
+        $modelRoot->refresh();
+
+        // Level 3
+        /** @var MultiCategory $node31 */
+        $node31 = static::model(['title' => 'child 3.1']);
+        $node31->appendTo($node21)->save();
+        $modelRoot->refresh();
+
+        $collection = MultiCategory::parentsByModelId($node31->id)->get();
+
+        self::assertCount(2, $collection);
+    }
+
+    #[Test]
+    public function andSelf(): void
+    {
+        /** @var MultiCategory $modelRoot */
+        $modelRoot = static::model(['title' => 'root node']);
+        $modelRoot->save();
+
+        $treeId = $modelRoot->tree_id;
+        static::assertNotNull($treeId);
+
+        // Level 2
+        /** @var MultiCategory $node21 */
+        $node21 = static::model(['title' => 'child 2.1']);
+        $node21->appendTo($modelRoot)->save();
+        $modelRoot->refresh();
+
+        // Level 3
+        /** @var MultiCategory $node31 */
+        $node31 = static::model(['title' => 'child 3.1']);
+        $node31->appendTo($node21)->save();
+        $modelRoot->refresh();
+
+        ///
+
+        /** @var MultiCategory $modelRoot2 */
+        $modelRoot2 = static::model(['title' => 'root node 2']);
+        $modelRoot2->save();
+
+        // Level 2
+        /** @var MultiCategory $node221 */
+        $node221 = static::model(['title' => 'child 22.1']);
+        $node221->appendTo($modelRoot2)->save();
+        $modelRoot2->refresh();
+
+        // Level 3
+        /** @var MultiCategory $node231 */
+        $node231 = static::model(['title' => 'child 23.1']);
+        $node231->appendTo($node221)->save();
+        $modelRoot2->refresh();
+
+        $collection = MultiCategory::parentsByModelId($node31->id, andSelf: true)->get();
+        self::assertCount(3, $collection);
+
+        $collection = MultiCategory::parentsByModelId($node31->id, 2)->get();
+        self::assertCount(0, $collection);
+
+        $collection = MultiCategory::parentsByModelId($node31->id, 1)->get();
+        self::assertCount(1, $collection);
+
+        $collection = MultiCategory::parentsByModelId($node31->id, 1, true)->get();
+        self::assertCount(2, $collection);
+
+        $collection = MultiCategory::parentsByModelId($node231->id)->get();
+        self::assertCount(2, $collection);
+    }
+}


### PR DESCRIPTION
…lder

## Summary by Sourcery

Introduce parentsByModelId and columnWithTbl to QueryBuilder, update existing methods to use qualified columns, add tests for parentsByModelId, and enhance documentation with new query examples

New Features:
- Add parentsByModelId method to QueryBuilder to fetch parent nodes by model ID without loading the model
- Add columnWithTbl helper method to QueryBuilder to qualify columns with their table name

Enhancements:
- Refactor defaultOrder and whereNodeBetween in QueryBuilder to use columnWithTbl for table-qualified columns
- Expand documentation with usage examples for new and existing query methods (root, notRoot, parentsByModelId, byTree, toLevel, byParent)

Documentation:
- Update ReceivingNodes.md to document new query builder methods

Tests:
- Add functional tests for parentsByModelId covering basic retrieval, andSelf option, and level filtering